### PR TITLE
DHIS2-Integration Module Config and ART Report Mapping Config

### DIFF
--- a/openmrs/apps/home/extension.json
+++ b/openmrs/apps/home/extension.json
@@ -118,6 +118,16 @@
     "icon": "fa fa-terminal",
     "order": 12,
     "requiredPrivilege": "app:admin"
+  },
+  "possible_dhis_2_integration": {
+	"id": "possible.dhis2Integration",
+	"extensionPointId": "org.bahmni.home.dashboard",
+	"type": "link",
+	"label": "DHIS2 integration",
+	"url": "/dhis-integration/index.html",
+	"icon": "fa-book",
+	"order": 11,
+	"requiredPrivilege": "app:reports"
   }
 
 }

--- a/openmrs/apps/home/extension.json
+++ b/openmrs/apps/home/extension.json
@@ -118,6 +118,16 @@
     "icon": "fa fa-terminal",
     "order": 12,
     "requiredPrivilege": "app:admin"
+  },
+  "possible_dhis_2_integration": {
+    "id": "possible.dhis2Integration",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "label": "DHIS2 integration",
+    "url": "/dhis-integration/index.html",
+    "icon": "fa-book",
+    "order": 11,
+    "requiredPrivilege": "app:reports"
   }
 
 }

--- a/openmrs/apps/reports/reports.json
+++ b/openmrs/apps/reports/reports.json
@@ -813,6 +813,55 @@
       "config": {
           "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/tally.sql"
 			}
-	}
+	},
+	
+	"HIV Care and Treatment 2020a": {
+        "name": "HIV Care and Treatment 2020a",
+        "DHISProgram": true,
+        "type": "concatenated",
+        "config": {
+            "reports": [
+				{
+                    "name": "HIV Care - New and Current Number of Persons Enrolled on Pre-ART",
+                    "type": "MRSGeneric",
+                    "config": {
+                        "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/SECTION1.sql"
+                    }
+                }
+				,
+				{
+                    "name": "ART Care - New and Current Number of Persons Started on ART",
+                    "type": "MRSGeneric",
+                    "config": {
+                        "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/SECTION2.sql"
+                    }
+                }
+				,
+				{
+                    "name": "TB Screening Among HIV Clients",
+                    "type": "MRSGeneric",
+                    "config": {
+                        "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/SECTION3.sql"
+                    }
+                }
+				,
+				{
+                    "name": "Clients Who Received Cotrimox Prophylaxis",
+                    "type": "MRSGeneric",
+                    "config": {
+                        "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/SECTION8.sql"
+                    }
+                }
+				,
+                {
+                    "name": "Adult and Children on Nutritional Supplement",
+                    "type": "MRSGeneric",
+                    "config": {
+                        "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/SECTION9.sql"
+                    }
+                }
+            ]
+        }
+    }
 
 }


### PR DESCRIPTION
1. Include Bahmni-DHIS2 Integration Module Icon on Bahmni landing page
-This is not done automatically by the installation process
2. Mark Bahmni ART (HIV Care and Treatment 2020a) report for mapping to DHIS2 and have it listed under the integration module UI
