### PR TITLE
Hide Rapid test fields in Self Test

### DIFF
--- a/openmrs/apps/clinical/formConditions.js
+++ b/openmrs/apps/clinical/formConditions.js
@@ -1538,7 +1538,7 @@ Bahmni.ConceptSet.FormConditions.rules = {
                         }
                 else if (testingStrategy.includes('HIVTC, Self Test') && !testingStrategy.includes('HIVTC, Rapid Test')) {
                         conditions.show.push("HTC, Date Of Distribution","HTC, Distribution Mode","HTC, Kit Collected For","HTC, Key Pop","HTC, Tested for HIV in The Past 12 Months","HTC, HIVST Results");
-                        conditions.hide.push("HTC, Pre-test Counseling Set","HTC, Post-test Counseling Set");
+                        conditions.hide.push("HTC, Pre-test Counseling Set","HTC, HIV Test","HTC, Post-test Counseling Set");
                        
                         conditions.hide.push("ART, Condoms Dispensed");
                         conditions.hide.push("HIVTC, TB Screened");


### PR DESCRIPTION
In the HTS Form, Some of the madatory rapid test fields appeared when they tried to save the self the test potion. 