### PR TITLE
LPA susceptibility result fix

### DIFF
--- a/openmrs/apps/clinical/app.json
+++ b/openmrs/apps/clinical/app.json
@@ -471,7 +471,6 @@
 
 
 			"LPA Susceptibility result" : {
-				"required": true,
 				"multiSelect": true
 			},
 			"OI, Opportunistic infections" : {


### PR DESCRIPTION
The LPA susceptibility result is no longer compulsory because the result is not always available