### PR TITLE
Remove compulsoriness of SD Bioline

### DIFF
--- a/openmrs/apps/clinical/app.json
+++ b/openmrs/apps/clinical/app.json
@@ -405,7 +405,7 @@
 				"required": true
 			},
 			"HTC, SD Bioline Tie Breaker": {
-				"required": true
+				"required": false
 			},
 			"HTC, DNA PCR Test Results": {
 				"required": true


### PR DESCRIPTION
SD Bioline is not available in most health centres at the moment so it should not be compulsory for indeterminate results