### PR TITLE
Intakes anc tb

### DIFF
--- a/openmrs/apps/reports/sql/ANC_List.sql
+++ b/openmrs/apps/reports/sql/ANC_List.sql
@@ -1,0 +1,409 @@
+select distinct patientIdentifier,
+				patientName,
+				Age,
+				ANC_visit,
+				Trimester,
+				Estimated_Date_Delivery,
+				High_Risk_Pregnancy,
+				Syphilis_Screening_Results,
+				Syphilis_Treatment_Completed
+from obs o
+inner join
+(
+
+SELECT ID, patientIdentifier , patientName, Age, ANC_visit, Trimester
+FROM
+(
+-- FIRST ANC, 1ST TRIMESTER
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        '1st_trimester' as 'Trimester'
+from obs o
+    -- First ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4659
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- 1st trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric < 13)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE) 
+)AS first_anc_1st_trimester
+
+
+UNION
+
+-- SUBSEQUENT, 1ST TRIMESTER
+SELECT ID, patientIdentifier , patientName, Age, ANC_visit, Trimester
+FROM
+(
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        '1st_trimester' as 'Trimester'
+from obs o
+    -- First ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4660
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- 1st trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric < 13)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+)AS subsequent_1st_trimester
+
+
+UNION
+SELECT ID,patientIdentifier ,patientName, Age, ANC_visit, Trimester
+FROM
+(
+-- FIRST ANC, 2ND TRIMESTER
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        '2nd_trimester' as 'Trimester'
+from obs o
+    -- First ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4659
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- 2nd trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric >= 13 and value_numeric < 25)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+)AS first_2nd_trimester
+
+
+UNION
+
+SELECT ID, patientIdentifier, patientName, Age, ANC_visit, Trimester
+FROM
+(
+-- SUBSEQUENT, 2ND TRIMESTER
+
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        '2nd_trimester' as 'Trimester'
+from obs o
+    -- First ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4660
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- 1st trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric >= 13 and value_numeric < 25)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+) AS subsquent_2nd_trimester
+
+    UNION
+
+SELECT ID, patientIdentifier,patientName, Age, ANC_visit, Trimester
+FROM
+(
+    -- FIRST ANC, 3RD TRIMESTER
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        '3rd_trimester' as 'Trimester'
+from obs o
+    -- First ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4659
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- 3rd trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric > 25)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+)AS first_3rd_trimester
+
+
+UNION
+
+
+SELECT ID, patientIdentifier,patientName, Age, ANC_visit, Trimester
+FROM
+(
+-- SUBSEQUENT, 3RD TRIMESTER
+
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        '3rd_trimester' as 'Trimester'
+from obs o
+    -- Subsequent ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4660
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- 3rd trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric > 25)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE) 
+
+)AS subsequent_3rd_trimester
+
+UNION
+
+SELECT ID, patientIdentifier,patientName, Age, ANC_visit, Trimester
+FROM
+(
+-- FIRST ANC NO GESTATIONAL PERIOD
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        'NULL' as 'Trimester'
+from obs o
+    -- First ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4659
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- no trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id not in (select o.person_id from obs o where concept_id = 2423)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+)AS first_no_trimester
+
+
+UNION
+
+SELECT ID, patientIdentifier,patientName, Age, ANC_visit, Trimester
+FROM
+(
+-- SUBSEQUENT, NO GESTATIONAL PERIOD
+
+select distinct patient.patient_id AS Id,
+						patient_identifier.identifier AS patientIdentifier,
+						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
+                        'NULL' as 'Trimester'
+from obs o
+    -- Subsequent ANC Clients
+     INNER JOIN patient ON o.person_id = patient.patient_id 
+	    AND o.concept_id = 4658 and o.value_coded = 4660
+	    AND patient.voided = 0 AND o.voided = 0
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+
+    -- no trimester
+    AND o.person_Id in (select id
+								FROM
+								( 
+									select distinct o.person_id AS Id,
+									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+
+									from obs o
+									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
+									INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3	
+								) as a
+												)
+    INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
+    INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
+    AND o.person_id not in (select o.person_id from obs o where concept_id = 2423)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+)AS subsquent_no_trimester
+) AS ANC
+ON o.person_id = ID
+
+-- EDD
+left outer join
+	(
+	select person_id,CAST(value_datetime AS DATE) as Estimated_Date_Delivery
+	from obs where concept_id = 4627 and voided = 0
+	)intake_date
+	on ANC.Id = intake_date.person_id
+
+-- High Risk Pregnancy
+left outer join
+	(
+	select person_id, value_coded as Risk_Code
+	from obs where concept_id = 4352 and voided = 0
+	)High_Risk_Preg
+
+	inner join
+	(
+		select concept_id, name AS High_Risk_Pregnancy
+			from concept_name 
+				where name in ('No Risk', 'Age less than 16 years', 'Age more than 40 years', 'History 3 or more consecutive spontaneous miscarriages',
+								'Birth Weight< 2500g', 'Birth Weight > 4500g', 'Previous Hx of Hypertension/pre-eclampsia/eclampsia', 'Isoimmunization Rh(-)',
+								'Renal Disease', 'Cardiac Disease', 'Diabetes', 'Known Substance Abuse', 'Pelvic Mass', 'Other Medical Problems', 
+								'Previous Surgery on Reproductive Tract', 'Other Answer') 
+	) concept_name
+	on concept_name.concept_id = High_Risk_Preg.Risk_Code 
+
+on High_Risk_Preg.person_id = ANC.Id
+
+-- Syphilis_Screening_Results
+left outer join
+	(
+
+		select distinct a.person_id, Syphilis_Results.value_coded,
+				case 
+				when Syphilis_Results.value_coded = 4306 then 'Non Reactive'
+				when Syphilis_Results.value_coded = 4307 then 'Reactive'
+				when Syphilis_Results.value_coded = 4308 then 'Not done'
+				else 'NewResult' end as Syphilis_Screening_Results
+	from obs a
+	inner join 
+		( SELECT person_id, value_coded from obs o
+			where concept_id = 4305 and voided = 0
+		) Syphilis_Results
+
+		ON a.person_id = Syphilis_Results.person_id
+	
+
+	) Syphilis_Screening_Res
+
+on Syphilis_Screening_Res.person_id = ANC.Id
+
+-- Syphilis Treatment Completed
+left outer join
+	(
+	select person_id, value_coded as Treatment_Code
+	from obs where concept_id = 1732 and voided = 0
+	)Syphilis_Treatment_Comp
+
+	inner join
+	(
+		select concept_id, name AS Syphilis_Treatment_Completed
+			from concept_name 
+				where name in ('Yes','No','Not Applicable') 
+	) treatment_concept
+	on treatment_concept.concept_id = Syphilis_Treatment_Comp.Treatment_Code 
+
+on Syphilis_Treatment_Comp.person_id = ANC.Id

--- a/openmrs/apps/reports/sql/ANC_List.sql
+++ b/openmrs/apps/reports/sql/ANC_List.sql
@@ -18,7 +18,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         '1st_trimester' as 'Trimester'
 from obs o
@@ -26,15 +26,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4659
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- 1st trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -45,8 +45,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric < 13)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE) 
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE) 
 )AS first_anc_1st_trimester
 
 
@@ -59,7 +59,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         '1st_trimester' as 'Trimester'
 from obs o
@@ -67,15 +67,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4660
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- 1st trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -86,8 +86,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric < 13)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 )AS subsequent_1st_trimester
 
 
@@ -99,7 +99,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         '2nd_trimester' as 'Trimester'
 from obs o
@@ -107,15 +107,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4659
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- 2nd trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -126,8 +126,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric >= 13 and value_numeric < 25)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 )AS first_2nd_trimester
 
 
@@ -141,7 +141,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         '2nd_trimester' as 'Trimester'
 from obs o
@@ -149,15 +149,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4660
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- 1st trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -168,8 +168,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric >= 13 and value_numeric < 25)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 ) AS subsquent_2nd_trimester
 
     UNION
@@ -181,7 +181,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         '3rd_trimester' as 'Trimester'
 from obs o
@@ -189,15 +189,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4659
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- 3rd trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -208,8 +208,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric > 25)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 )AS first_3rd_trimester
 
 
@@ -224,7 +224,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         '3rd_trimester' as 'Trimester'
 from obs o
@@ -232,15 +232,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4660
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- 3rd trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -251,8 +251,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id in (select o.person_id from obs o where concept_id = 2423 and value_numeric > 25)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE) 
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE) 
 
 )AS subsequent_3rd_trimester
 
@@ -265,7 +265,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4659 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         'NULL' as 'Trimester'
 from obs o
@@ -273,15 +273,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4659
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- no trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -292,8 +292,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id not in (select o.person_id from obs o where concept_id = 2423)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 )AS first_no_trimester
 
 
@@ -307,7 +307,7 @@ FROM
 select distinct patient.patient_id AS Id,
 						patient_identifier.identifier AS patientIdentifier,
 						concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-						floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age,
+						floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
 						(select name from concept_name cn where cn.concept_id = 4660 and concept_name_type='FULLY_SPECIFIED') AS ANC_visit,
                         'NULL' as 'Trimester'
 from obs o
@@ -315,15 +315,15 @@ from obs o
      INNER JOIN patient ON o.person_id = patient.patient_id 
 	    AND o.concept_id = 4658 and o.value_coded = 4660
 	    AND patient.voided = 0 AND o.voided = 0
-	    AND CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-		AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	    AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
     -- no trimester
     AND o.person_Id in (select id
 								FROM
 								( 
 									select distinct o.person_id AS Id,
-									floor(datediff(CAST('2022-10-30' AS DATE), person.birthdate)/365) AS Age
+									floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age
 
 									from obs o
 									INNER JOIN person ON person.person_id = o.person_id AND person.voided = 0
@@ -334,8 +334,8 @@ from obs o
 	INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
     INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3 AND patient_identifier.preferred=1
     AND o.person_id not in (select o.person_id from obs o where concept_id = 2423)
-	WHERE CAST(o.obs_datetime AS DATE) >= CAST('2022-10-01' AS DATE)
-	AND CAST(o.obs_datetime AS DATE) <= CAST('2022-10-30' AS DATE)
+	WHERE CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+	AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 )AS subsquent_no_trimester
 ) AS ANC
 ON o.person_id = ID

--- a/openmrs/apps/reports/sql/No_intakes.sql
+++ b/openmrs/apps/reports/sql/No_intakes.sql
@@ -1,36 +1,79 @@
-SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", age_group AS "Age Group", Age, Gender, location_name AS "Location"
+-- Clients with ART follows but no intakes
+(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS "Location", Status
 
 FROM
         (
-			SELECT distinct 
-							patient_identifier.identifier AS patientIdentifier,
-							p.identifier AS ART_Number,
-							concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-							observed_age_group.name AS age_group,
-							floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
-							person.gender AS Gender,
-							l.name as location_name
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			observed_age_group.name AS age_group,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(DATEDIFF(CAST('#endDate#' AS DATE),max(o.value_datetime)) <= 0," Active",
+				if(DATEDIFF(CAST('#endDate#' AS DATE),max(o.value_datetime)) <= 28 ," Missed",
+					if(DATEDIFF(CAST('#endDate#' AS DATE),max(o.value_datetime)) <= 89 ,"Defaulter","LTFU"))) as Status
 							
-			FROM obs o
-								INNER JOIN patient ON o.person_id = patient.patient_id
-								INNER JOIN patient_identifier p ON o.person_id = p.patient_id 
-								INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
-								INNER JOIN person_name ON person.person_id = person_name.person_id
-								INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
-								JOIN location l on o.location_id = l.location_id and l.retired=0
-								INNER JOIN reporting_age_group AS observed_age_group ON
-								CAST('#endDate#' AS DATE) BETWEEN (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
-								AND (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
-						   		WHERE observed_age_group.report_group_name = 'Modified_Ages'
-								AND o.person_id not in
-								(				
-									select person_id from obs where concept_id = 2249
-								)								
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		INNER JOIN reporting_age_group AS observed_age_group ON
+			CAST('#endDate#' AS DATE) 
+				BETWEEN (DATE_ADD(DATE_ADD(p.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
+				AND (DATE_ADD(DATE_ADD(p.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
+		WHERE observed_age_group.report_group_name = 'Modified_Ages'
+		AND o.person_id not in
+					(				
+						select person_id from obs where concept_id = 2249
+					)
+		AND o.person_id 								
+		AND p.voided = 0
+		group by pi1.identifier
+		order by Status
+			
+	) AS Patient_MissedAppointments
+ORDER BY 2)
+
+UNION
+-- clients with ART unique numbers but no intakes
+(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS "Location", Status
+
+FROM
+        (
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			observed_age_group.name AS age_group,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			'No ART Form' AS Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			INNER JOIN reporting_age_group AS observed_age_group ON
+				CAST('#endDate#' AS DATE) BETWEEN (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
+					AND (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
+			WHERE observed_age_group.report_group_name = 'Modified_Ages'
+			AND o.person_id not in
+				(				
+					select person_id from obs where concept_id in (2249,2403)
+				)								
 									
-								AND p.identifier_type = 5 
-								AND o.voided = 0
+			AND p.identifier_type in (5,12) 
+			AND o.voided = 0
+			group by patient_identifier.identifier
 			
 		) AS Patient_MissedAppointments
 
-ORDER BY 2;
-
+ORDER BY 2);

--- a/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_list.sql
+++ b/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_list.sql
@@ -1,150 +1,50 @@
-SELECT DISTINCT
-		location_name
-		, Identifier
-		, Name
-		, Gender
-		, Age
-		, Status
-FROM 
-(
+-- Clients with ART follows up forms
+SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS "Location", Status
 
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
+FROM
+        (
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status
+							
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		WHERE 	p.voided = 0
+		group by pi1.identifier
 
-		FROM
-		(
+UNION
+-- clients with ART unique numbers but no intakes
 
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			WHERE p.identifier_type in (5,12) 
+			AND o.voided = 0
+			AND o.person_id not in (select person_id from obs where concept_id = 2403 and voided = 0)
+			group by patient_identifier.identifier
+			
+		) AS Patient_MissedAppointments
 
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
-
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id not in (select distinct os.person_id from obs os where os.concept_id=2249)
-		GROUP BY IntakesRegistered.id
-
-) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
+ORDER BY 2

--- a/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_pivot.sql
+++ b/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_pivot.sql
@@ -1,335 +1,119 @@
+-- Clients with ART follows up forms
 SELECT DISTINCT
-	   Intakes_vs_Registrations_Agg.location_name AS Location,
-	   SUM(1) AS 'Total Registered',	   
-	   SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0)) AS Intakes,
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'	   
+	Intakes_table.Location,
+	SUM(1) AS 'Total Registered',
+	SUM(IF(Intakes_table.Status = 'Intake', 1, 0)) AS Intakes,
+	round((SUM(IF(Intakes_table.Status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
+	round((SUM(IF(Intakes_table.Status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'
 FROM
-(
+	(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS Location, Status
 
-SELECT DISTINCT
-		location_name
-		, id
-		, Identifier
-		, Name
-		, Gender
-		, Age
-		, Status
-FROM 
-(
+	FROM
+        
+	-- clients with ART Follow ups
+	(	
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status
+							
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		WHERE 	p.voided = 0
+		group by pi1.identifier
 
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
+UNION
+-- clients with ART unique numbers but no intakes
 
-		FROM
-		(
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			WHERE p.identifier_type in (5,12) 
+			AND o.voided = 0
+			AND o.person_id not in (select person_id from obs where concept_id = 2403 and voided = 0)
+			group by patient_identifier.identifier
 
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
-
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id not in (select distinct os.person_id from obs os where os.concept_id=2249)
-		GROUP BY IntakesRegistered.id
-
-) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
-
-
-
-) AS Intakes_vs_Registrations_Agg
-GROUP BY Intakes_vs_Registrations_Agg.location_name
-
+	) AS Location_summary
+) AS Intakes_table
+group by Intakes_table.Location
 
 UNION ALL
 
-
 SELECT DISTINCT
-	   'Total' AS Location,
-	   SUM(1) AS 'Total Registered',
-	   SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0)) AS Intakes,
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'	   
+	'Total' AS Location,
+	SUM(1) AS 'Total Registered',
+	SUM(IF(Intakes_table.Status = 'Intake', 1, 0)) AS Intakes,
+	round((SUM(IF(Intakes_table.Status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
+	round((SUM(IF(Intakes_table.Status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'
 FROM
-(
+	(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS Location, Status
 
+	FROM
+        
+	-- clients with ART Follow ups
+	(	
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status
+							
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		WHERE 	p.voided = 0
+		group by pi1.identifier
 
-SELECT DISTINCT
-		location_name
-		, id
-		, Identifier
-		, Name
-		, Gender
-		, Age
-		, Status
-FROM 
-(
+UNION
+-- clients with ART unique numbers but no intakes
 
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			WHERE p.identifier_type in (5,12) 
+			AND o.voided = 0
+			AND o.person_id not in (select person_id from obs where concept_id = 2403 and voided = 0)
+			group by patient_identifier.identifier
 
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
-
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id not in (select distinct os.person_id from obs os where os.concept_id=2249)
-		GROUP BY IntakesRegistered.id
-
-) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
-
-
-
-) AS Intakes_vs_Registrations_Agg
+	) AS Location_summary
+) AS Intakes_table

--- a/openmrs/apps/reports/sql/tb_notification_block2.sql
+++ b/openmrs/apps/reports/sql/tb_notification_block2.sql
@@ -26,20 +26,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- less than a year
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/30.4) < 12
-                and o.person_id in (
+                and FLOOR(DATEDIFF(current_date(),p.birthdate)/30.4) < 12 
+                 where o.concept_id = 2237
+                 and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		         and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)        
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-									)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))				
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+										)				
     )
     UNION
     (
@@ -49,20 +48,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- Age between 1year and 4years
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 1 and 4
-                and o.person_id in (
+                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 1 and 4 
+                 where o.concept_id = 2237
+                   and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -75,19 +73,19 @@ from
                 and p.gender = 'M'
                 -- Age between 5 - 9years
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 5 and 9
-                and o.person_id in (
+                 where
+                    o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
     UNION
@@ -98,20 +96,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- Age between 10 - 14 years
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 10 and 14
-                and o.person_id in (
+                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 10 and 14 
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)         
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -124,19 +121,18 @@ from
                 and p.gender = 'M'
                 -- Age between 15 - 19 yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 15 and 19
-                and o.person_id in (
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)        
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -149,20 +145,18 @@ from
                 and p.gender = 'M'
                 -- Age between 20 - 24 yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 20 and 24
-
-                and o.person_id in (
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -174,20 +168,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- Age between 25 - 34 yrs
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 25 and 34
-                and o.person_id in (
+               and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 25 and 34
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)        
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded in (1034, 1084)
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -199,20 +192,20 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- Age between 35 - 44 yrs
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 35 and 44
-                and o.person_id in (
+                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 34 and 45
+                 where
+                    o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
     UNION
@@ -224,19 +217,18 @@ from
                 and p.gender = 'M'
                 -- Age between 45 - 49 yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 45 and 49
-                and o.person_id in (
+                 where o.concept_id = 2237
+                   and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -248,20 +240,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- Age between 50 - 54 yrs
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 50 and 54
-                and o.person_id in (
+               and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 50 and 54
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
     UNION
@@ -273,19 +264,18 @@ from
                 and p.gender = 'M'
                 -- Age between 55 - 64  yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 55 and 64
-                and o.person_id in (
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)         
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -297,20 +287,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'M'
                 -- Age between 65+ yrs
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) >=65
-                and o.person_id in (
+                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) >= 65
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
 
     )
 
@@ -324,19 +313,19 @@ from
                 and p.gender = 'F'
                 -- less than a year
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/30.4) < 12
-                and o.person_id in (
+                 where
+                    o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
     )
     UNION
     (
@@ -347,22 +336,21 @@ from
                 and p.gender = 'F'
                 -- Age between 1year and 4years
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 1 and 4
-                and o.person_id in (
+                 where
+                    o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)           
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
-    )
-
+                                    )
+  )
     UNION
     (
         select distinct o.person_id as id, '5 -9 yrs' as outcome, 'Female' as patient_type
@@ -372,19 +360,18 @@ from
                 and p.gender = 'F'
                 -- Age between 5 - 9years
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 5 and 9
-                and o.person_id in (
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                      )
     )
     UNION
     (
@@ -394,20 +381,19 @@ from
                 and p.voided = 0 
                 and p.gender = 'F'
                 -- Age between 10 - 14 years
-                and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 10 and 14
-                and o.person_id in (
+               and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 10 and 14
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)           
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                        )
     )
 
     UNION
@@ -419,19 +405,18 @@ from
                 and p.gender = 'F'
                 -- Age between 15 - 19 yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 15 and 19
-                and o.person_id in (
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)           
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                                )
     )
 
     UNION
@@ -443,21 +428,19 @@ from
                 and p.gender = 'F'
                 -- Age between 20 - 24 yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 20 and 24
-
-                and o.person_id in (
+                 where  o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)           
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-										)
-                inner join patient_identifier pi on pi.patient_id = o.person_id 
-                and pi.identifier_type = 3
-														AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
+                                  )
     )
 
     UNION
@@ -469,20 +452,20 @@ from
                 and p.gender = 'F'
                 -- Age between 25 - 34 yrs
                 and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 25 and 34
-                and o.person_id in (
+                 where
+                    o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                    and o.person_id in (
                                     -- New and Relapse Clients
-                                    select distinct person_id
-                                        from obs
-                                        where concept_id = 3785
-                                        and value_coded = 1034 or value_coded =1084
-																				AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-										)
-                    inner join patient_identifier pi on pi.patient_id = o.person_id 
-                    and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-        )
+                                        select distinct person_id
+                                            from obs
+                                            where concept_id = 3785
+                                            and value_coded = 1034 or value_coded =1084
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                                    )
+    )
 
         UNION
         (
@@ -493,19 +476,18 @@ from
                     and p.gender = 'F'
                     -- Age between 35 - 44 yrs
                     and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 35 and 44
-                    and o.person_id in (
-                                    -- New and Relapse Clients
-                                        select distinct person_id
-                                            from obs
-                                            where concept_id = 3785
-                                            and value_coded = 1034 or value_coded =1084
-																					AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-											)
-                    inner join patient_identifier pi on pi.patient_id = o.person_id 
-                    and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                    where o.concept_id = 2237
+                        and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)           
+                        and o.person_id in (
+                                        -- New and Relapse Clients
+                                            select distinct person_id
+                                                from obs
+                                                where concept_id = 3785
+                                                and value_coded = 1034 or value_coded =1084
+                                                AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                        AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                                        )
         )
     UNION
         (
@@ -515,20 +497,19 @@ from
                     and p.voided = 0 
                     and p.gender = 'F'
                     -- Age between 45 - 49 yrs
-                    and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 45 and 49
-                   and o.person_id in (
-                                        -- New and Relapse Clients
-                                        select distinct person_id
-                                            from obs
-                                            where concept_id = 3785
-                                            and value_coded = 1034 or value_coded =1084
-																					AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-											)
-                    inner join patient_identifier pi on pi.patient_id = o.person_id 
-                    and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                   and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 45 and 49
+                  where o.concept_id = 2237
+                      and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		              and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                      and o.person_id in (
+                                      -- New and Relapse Clients
+                                          select distinct person_id
+                                              from obs
+                                              where concept_id = 3785
+                                              and value_coded = 1034 or value_coded =1084
+                                              AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                      AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                                    )
         )
 
         UNION
@@ -540,21 +521,21 @@ from
                     and p.gender = 'F'
                     -- Age between 50 - 54 yrs
                     and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 50 and 54
-                    and o.person_id in (
+                    where o.concept_id = 2237
+                        and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
+                        and o.person_id in (
                                         -- New and Relapse Clients
-                                        select distinct person_id
-                                            from obs
-                                            where concept_id = 3785
-                                            and value_coded = 1034 or value_coded =1084
-																					AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-											)
-                    inner join patient_identifier pi on pi.patient_id = o.person_id 
-                    and pi.identifier_type = 3
-															AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                            select distinct person_id
+                                                from obs
+                                                where concept_id = 3785
+                                                and value_coded = 1034 or value_coded =1084
+                                                AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                        AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
+                                        )
         )
+
         UNION
         (
             select distinct o.person_id as id, '55 - 64 yrs' as outcome, 'Female' as patient_type
@@ -563,20 +544,19 @@ from
                     and p.voided = 0 
                     and p.gender = 'F'
                     -- Age between 55 - 64  yrs
-                    and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 55 and 64
+                   and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) between 55 and 64
+                   where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)          
                     and o.person_id in (
-                                        -- New and Relapse Clients
+                                    -- New and Relapse Clients
                                         select distinct person_id
                                             from obs
                                             where concept_id = 3785
                                             and value_coded = 1034 or value_coded =1084
-																					AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-											)
-                    inner join patient_identifier pi on pi.patient_id = o.person_id 
-                    and pi.identifier_type = 3
-										AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
+                                   )
         )
 
         UNION
@@ -587,22 +567,21 @@ from
                     and p.voided = 0 
                     and p.gender = 'F'
                     -- Age between 65+ yrs
-                    and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) >=65
+                    and FLOOR(DATEDIFF(current_date(),p.birthdate)/365) >= 65
+                 where o.concept_id = 2237
+                    and CAST(o.value_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		            and CAST(o.value_datetime AS DATE) <= CAST('#endDate#' AS DATE)           
                     and o.person_id in (
-                                        -- New and Relapse Clients
+                                    -- New and Relapse Clients
                                         select distinct person_id
                                             from obs
                                             where concept_id = 3785
                                             and value_coded = 1034 or value_coded =1084
-																					AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
-											)
-                        inner join patient_identifier pi on pi.patient_id = o.person_id 
-                        and pi.identifier_type = 3
-																AND MONTH(obs_datetime) = MONTH(CAST('#endDate#' AS DATE))
-										AND YEAR(obs_datetime) =  YEAR(CAST('#endDate#' AS DATE))
+                                            AND CAST(o.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+		                                    AND CAST(o.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
-        )
+                                    )
+      )  
 ) allDataRows
 ) pivotTable
 group by patient_type


### PR DESCRIPTION
TB_Enrolled_list.sql 
   Added Key Populations, HIV Status, Clients on ART, TB Diagnosis
   Considers start and end date selected
                               
**Reports affected**
TB-003 | TB Notification (List)
TB-011 | New and Relapse Enrolled on TB (List)
TB-012 | DSD TB_ART (List)
TB-013 | DSD TB_ART (PIVOT)

ANC_List.sql - Added Syphilis Screening Results, Syphilis Treatment Completed
**Reports affected**
MCH-005 | Ante Natal Care (ANC) (List)

No_intakes.sql 
       Identifies all clients who have art follow up but no intakes, regardless of whether they have art number or not.
       Identifiers all clients who have ART number but no intakes, regardless of whether they have ART follow-up form or not.
       Removed the age_group column
       Addition of the column status; aimed at classifying as to whether the clients is 'active', 'missed', 'defaulted', 'LTFU' or 
       does not have ART follow up form
       Arranging the report in order of their status, starting with the active clients and ending with those without ART follow up 
       form
**Reports affected**
ART-021 | ART Client Without Intakes (List)

tb_notification_block2 
  Corrected to pick only new and relapse patients using TB Start date to determine initiation
  Considers start and end date selected
**Reports affected**
TB-008 | New and Relapse Enrolled on TB

art_clients_registered_vs_client_intakes_joinversion_list.sql - picks ART clients, using either the follow-up form or the ART Number
**Reports affected**
ART-019 | Registered ART Clients with Intakes (List)

art_clients_registered_vs_client_intakes_joinversion_pivot.sql - picks ART clients, using either the follow-up form or the ART Number
**Reports affected**
ART-020 | Registered ART Clients with Intakes (Pivot