### PR TITLE
Intakes report

### DIFF
--- a/openmrs/apps/reports/sql/No_intakes.sql
+++ b/openmrs/apps/reports/sql/No_intakes.sql
@@ -1,36 +1,79 @@
-SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", age_group AS "Age Group", Age, Gender, location_name AS "Location"
+-- Clients with ART follows but no intakes
+(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS "Location", Status
 
 FROM
         (
-			SELECT distinct 
-							patient_identifier.identifier AS patientIdentifier,
-							p.identifier AS ART_Number,
-							concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
-							observed_age_group.name AS age_group,
-							floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
-							person.gender AS Gender,
-							l.name as location_name
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			observed_age_group.name AS age_group,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(DATEDIFF(CAST('#endDate#' AS DATE),max(o.value_datetime)) <= 0," Active",
+				if(DATEDIFF(CAST('#endDate#' AS DATE),max(o.value_datetime)) <= 28 ," Missed",
+					if(DATEDIFF(CAST('#endDate#' AS DATE),max(o.value_datetime)) <= 89 ,"Defaulter","LTFU"))) as Status
 							
-			FROM obs o
-								INNER JOIN patient ON o.person_id = patient.patient_id
-								INNER JOIN patient_identifier p ON o.person_id = p.patient_id 
-								INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
-								INNER JOIN person_name ON person.person_id = person_name.person_id
-								INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
-								JOIN location l on o.location_id = l.location_id and l.retired=0
-								INNER JOIN reporting_age_group AS observed_age_group ON
-								CAST('#endDate#' AS DATE) BETWEEN (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
-								AND (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
-						   		WHERE observed_age_group.report_group_name = 'Modified_Ages'
-								AND o.person_id not in
-								(				
-									select person_id from obs where concept_id = 2249
-								)								
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		INNER JOIN reporting_age_group AS observed_age_group ON
+			CAST('#endDate#' AS DATE) 
+				BETWEEN (DATE_ADD(DATE_ADD(p.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
+				AND (DATE_ADD(DATE_ADD(p.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
+		WHERE observed_age_group.report_group_name = 'Modified_Ages'
+		AND o.person_id not in
+					(				
+						select person_id from obs where concept_id = 2249
+					)
+		AND o.person_id 								
+		AND p.voided = 0
+		group by pi1.identifier
+		order by Status
+			
+	) AS Patient_MissedAppointments
+ORDER BY 2)
+
+UNION
+-- clients with ART unique numbers but no intakes
+(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS "Location", Status
+
+FROM
+        (
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			observed_age_group.name AS age_group,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			'No ART Form' AS Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			INNER JOIN reporting_age_group AS observed_age_group ON
+				CAST('#endDate#' AS DATE) BETWEEN (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
+					AND (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
+			WHERE observed_age_group.report_group_name = 'Modified_Ages'
+			AND o.person_id not in
+				(				
+					select person_id from obs where concept_id in (2249,2403)
+				)								
 									
-								AND p.identifier_type = 5 
-								AND o.voided = 0
+			AND p.identifier_type in (5,12) 
+			AND o.voided = 0
+			group by patient_identifier.identifier
 			
 		) AS Patient_MissedAppointments
 
-ORDER BY 2;
-
+ORDER BY 2);

--- a/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_list.sql
+++ b/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_list.sql
@@ -1,150 +1,50 @@
-SELECT DISTINCT
-		location_name
-		, Identifier
-		, Name
-		, Gender
-		, Age
-		, Status
-FROM 
-(
+-- Clients with ART follows up forms
+SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS "Location", Status
 
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
+FROM
+        (
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status
+							
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		WHERE 	p.voided = 0
+		group by pi1.identifier
 
-		FROM
-		(
+UNION
+-- clients with ART unique numbers but no intakes
 
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			WHERE p.identifier_type in (5,12) 
+			AND o.voided = 0
+			AND o.person_id not in (select person_id from obs where concept_id = 2403 and voided = 0)
+			group by patient_identifier.identifier
+			
+		) AS Patient_MissedAppointments
 
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
-
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id not in (select distinct os.person_id from obs os where os.concept_id=2249)
-		GROUP BY IntakesRegistered.id
-
-) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
+ORDER BY 2

--- a/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_pivot.sql
+++ b/openmrs/apps/reports/sql/art_clients_registered_vs_client_intakes_joinversion_pivot.sql
@@ -1,335 +1,119 @@
+-- Clients with ART follows up forms
 SELECT DISTINCT
-	   Intakes_vs_Registrations_Agg.location_name AS Location,
-	   SUM(1) AS 'Total Registered',	   
-	   SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0)) AS Intakes,
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'	   
+	Intakes_table.Location,
+	SUM(1) AS 'Total Registered',
+	SUM(IF(Intakes_table.Status = 'Intake', 1, 0)) AS Intakes,
+	round((SUM(IF(Intakes_table.Status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
+	round((SUM(IF(Intakes_table.Status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'
 FROM
-(
+	(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS Location, Status
 
-SELECT DISTINCT
-		location_name
-		, id
-		, Identifier
-		, Name
-		, Gender
-		, Age
-		, Status
-FROM 
-(
+	FROM
+        
+	-- clients with ART Follow ups
+	(	
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status
+							
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		WHERE 	p.voided = 0
+		group by pi1.identifier
 
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
+UNION
+-- clients with ART unique numbers but no intakes
 
-		FROM
-		(
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			WHERE p.identifier_type in (5,12) 
+			AND o.voided = 0
+			AND o.person_id not in (select person_id from obs where concept_id = 2403 and voided = 0)
+			group by patient_identifier.identifier
 
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
-
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id not in (select distinct os.person_id from obs os where os.concept_id=2249)
-		GROUP BY IntakesRegistered.id
-
-) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
-
-
-
-) AS Intakes_vs_Registrations_Agg
-GROUP BY Intakes_vs_Registrations_Agg.location_name
-
+	) AS Location_summary
+) AS Intakes_table
+group by Intakes_table.Location
 
 UNION ALL
 
-
 SELECT DISTINCT
-	   'Total' AS Location,
-	   SUM(1) AS 'Total Registered',
-	   SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0)) AS Intakes,
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
-	   round((SUM(IF(Intakes_vs_Registrations_Agg.status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'	   
+	'Total' AS Location,
+	SUM(1) AS 'Total Registered',
+	SUM(IF(Intakes_table.Status = 'Intake', 1, 0)) AS Intakes,
+	round((SUM(IF(Intakes_table.Status = 'Intake', 1, 0))/SUM(1))*100) AS '% with Intakes',
+	round((SUM(IF(Intakes_table.Status = 'No Intake', 1, 0))/SUM(1))*100) AS '% without Intakes'
 FROM
-(
+	(SELECT distinct patientIdentifier AS "Patient Identifier", ART_Number AS "ART Number", patientName AS "Patient Name", Age, Gender, location_name AS Location, Status
 
+	FROM
+        
+	-- clients with ART Follow ups
+	(	
+		SELECT distinct 
+			pi1.identifier AS patientIdentifier,
+			pi2.identifier AS ART_Number,
+			concat(pn.given_name, ' ', pn.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+			p.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status
+							
+		FROM person p
+		
+		INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 AND o.person_id in (select person_id from obs where concept_id = 2403 and voided = 0)
+		INNER JOIN person_name pn ON p.person_id = pn.person_id
+		INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+		LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type in (5,12)
+		JOIN location l on o.location_id = l.location_id and l.retired=0
+		WHERE 	p.voided = 0
+		group by pi1.identifier
 
-SELECT DISTINCT
-		location_name
-		, id
-		, Identifier
-		, Name
-		, Gender
-		, Age
-		, Status
-FROM 
-(
+UNION
+-- clients with ART unique numbers but no intakes
 
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
+		SELECT distinct 
+			patient_identifier.identifier AS patientIdentifier,
+			p.identifier AS ART_Number,
+			concat(person_name.given_name, ' ', person_name.family_name) AS patientName,
+			floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
+			person.gender AS Gender,
+			l.name as location_name,
+			if(o.person_id in (select person_id from obs where concept_id = 2249),"Intake","No Intake") as Status				
+		FROM obs o
+			INNER JOIN patient ON o.person_id = patient.patient_id
+			INNER JOIN patient_identifier p ON o.person_id = p.patient_id
+			INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
+			INNER JOIN person_name ON person.person_id = person_name.person_id
+			INNER JOIN patient_identifier ON patient_identifier.patient_id = person.person_id AND patient_identifier.identifier_type = 3
+			JOIN location l on o.location_id = l.location_id and l.retired=0
+			WHERE p.identifier_type in (5,12) 
+			AND o.voided = 0
+			AND o.person_id not in (select person_id from obs where concept_id = 2403 and voided = 0)
+			group by patient_identifier.identifier
 
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
-
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE)and o.date_created <= CAST('#endDate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id and pi.identifier_type=5
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=2249
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#endDate#' AS DATE) and o.date_created <= CAST('#endDate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id not in (select distinct os.person_id from obs os where os.concept_id=2249)
-		GROUP BY IntakesRegistered.id
-
-) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
-
-
-
-) AS Intakes_vs_Registrations_Agg
+	) AS Location_summary
+) AS Intakes_table


### PR DESCRIPTION
No_intakes.sql
Identifies all clients who have art follow up but no intakes, regardless of whether they have art number or not.
Identifiers all clients who have ART number but no intakes, regardless of whether they have ART follow-up form or not.
Removed the age_group column
Addition of the column status; aimed at classifying as to whether the clients is 'active', 'missed', 'defaulted', 'LTFU' or
does not have ART follow up form
Arranging the report in order of their status, starting with the active clients and ending with those without ART follow up
form
Reports affected
ART-021 | ART Client Without Intakes (List)

art_clients_registered_vs_client_intakes_joinversion_list.sql - picks ART clients, using either the follow-up form or the ART Number
Reports affected
ART-019 | Registered ART Clients with Intakes (List)

art_clients_registered_vs_client_intakes_joinversion_pivot.sql - picks ART clients, using either the follow-up form or the ART Number
Reports affected
ART-020 | Registered ART Clients with Intakes (Pivot)