### PR TITLE
TB Intakes Corrections and removing deaths from txnew section of txcurr

### DIFF
--- a/openmrs/apps/reports/reports.json
+++ b/openmrs/apps/reports/reports.json
@@ -1252,7 +1252,7 @@
         "name": "TB-019 | TB Intakes (List)",
         "type": "MRSGeneric",
         "config": {
-            "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/TB_Patients_List.sql"
+            "sqlPath": "/var/www/bahmni_config/openmrs/apps/reports/sql/TB_clients_registered_vs_client_intakes_joinversion_list.sql"
         }
     },
     "TB_Clients_Registered_Vs_Clients_Intakes_Pivot": {

--- a/openmrs/apps/reports/sql/TB_clients_registered_vs_client_intakes_joinversion_pivot.sql
+++ b/openmrs/apps/reports/sql/TB_clients_registered_vs_client_intakes_joinversion_pivot.sql
@@ -9,7 +9,6 @@ FROM
 
 SELECT DISTINCT
 		location_name
-		, id
 		, Identifier
 		, Name
 		, Gender
@@ -20,9 +19,8 @@ FROM
 
 		SELECT DISTINCT
 				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
+				, patientIdentifier as Identifier
+				, patientName as Name
 				, gender as Gender
 				, age as Age
 				, status as Status
@@ -31,135 +29,42 @@ FROM
 		(
 
 			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
+					intake.location_name
+					, intake.patientName
+					, intake.gender
+					, intake.age
+					, intake.patientIdentifier
+                    ,intake.status
 			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE)and o.date_created <= CAST('#enddate#' AS DATE)) reg
-
-					LEFT JOIN 
-
 					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=4153
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE) and o.date_created <= CAST('#enddate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
+							pi1.identifier AS patientIdentifier,
+                            pi2.identifier AS TB_Number,
+                            concat(pn.given_name, ' ', pn.family_name) AS patientName,
+                            floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+                            p.gender AS Gender,
+                            l.name as location_name,
+                            if(o.person_id in 
+                                        (select person_id from obs where concept_id = 4153  and voided = 0
+                                        -- TB Intake form captured within a year of the start date
+                                        and CAST(obs_datetime AS DATE) >= DATE_ADD(CAST('#startDate#'AS DATE), INTERVAL -12 MONTH) ),"Intake","No Intake") as Status
+					FROM person p
+							INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 
+                            AND o.person_id in 
+                                            (select person_id from obs where concept_id = 1158
+                                            and CAST(obs_datetime AS Date) >= CAST('#startDate#'AS DATE) 
+                                            and CAST(obs_datetime AS Date) <= CAST('#endDate#'AS DATE)
+                                            and voided = 0)
+                                INNER JOIN person_name pn ON p.person_id = pn.person_id and pn.preferred  = 1
+                                INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+                                LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type = 7
+                                JOIN location l on o.location_id = l.location_id and l.retired=0
+                                WHERE p.voided = 0
+                                group by pi1.identifier) intake
 
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE)and o.date_created <= CAST('#enddate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=4153
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE) and o.date_created <= CAST('#enddate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id in (select distinct os.person_id from obs os where os.concept_id=1158)
-		GROUP BY IntakesRegistered.id
+					) AS IntakesRegistered
 
 ) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
-
-
+ORDER BY  RegistrationVsIntakes.Identifier, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
 
 ) AS Intakes_vs_Registrations_Agg
 GROUP BY Intakes_vs_Registrations_Agg.location_name
@@ -177,10 +82,8 @@ SELECT DISTINCT
 FROM
 (
 
-
 SELECT DISTINCT
 		location_name
-		, id
 		, Identifier
 		, Name
 		, Gender
@@ -191,9 +94,8 @@ FROM
 
 		SELECT DISTINCT
 				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
+				, patientIdentifier as Identifier
+				, patientName as Name
 				, gender as Gender
 				, age as Age
 				, status as Status
@@ -202,134 +104,41 @@ FROM
 		(
 
 			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
+					intake.location_name
+					, intake.patientName
+					, intake.gender
+					, intake.age
+					, intake.patientIdentifier
+                    ,intake.status
 			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE)and o.date_created <= CAST('#enddate#' AS DATE)) reg
-
-					LEFT JOIN 
-
 					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=4153
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE) and o.date_created <= CAST('#enddate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		GROUP BY IntakesRegistered.id
-		HAVING IntakesRegistered.status = 'Intake'
+							pi1.identifier AS patientIdentifier,
+                            pi2.identifier AS TB_Number,
+                            concat(pn.given_name, ' ', pn.family_name) AS patientName,
+                            floor(datediff(CAST('#endDate#' AS DATE), p.birthdate)/365) AS Age,
+                            p.gender AS Gender,
+                            l.name as location_name,
+                            if(o.person_id in 
+                                        (select person_id from obs where concept_id = 4153  and voided = 0
+                                        -- TB Intake form captured within a year of the start date
+                                        and CAST(obs_datetime AS DATE) >= DATE_ADD(CAST('#startDate#'AS DATE), INTERVAL -12 MONTH) ),"Intake","No Intake") as Status
+					FROM person p
+							INNER JOIN obs o ON o.person_id = p.person_id AND o.voided = 0 
+                            AND o.person_id in 
+                                            (select person_id from obs where concept_id = 1158
+                                            and CAST(obs_datetime AS Date) >= CAST('#startDate#'AS DATE) 
+                                            and CAST(obs_datetime AS Date) <= CAST('#endDate#'AS DATE)
+                                            and voided = 0)
+                                INNER JOIN person_name pn ON p.person_id = pn.person_id and pn.preferred  = 1
+                                INNER JOIN patient_identifier pi1 ON pi1.patient_id = p.person_id AND pi1.voided = 0 and pi1.preferred = 1 AND pi1.identifier_type = 3
+                                LEFT JOIN patient_identifier pi2 ON pi2.patient_id = p.person_id AND pi2.identifier_type = 7
+                                JOIN location l on o.location_id = l.location_id and l.retired=0
+                                WHERE p.voided = 0
+                                group by pi1.identifier) intake
 
-
-		UNION 
-
-		SELECT DISTINCT
-				location_name
-				, id
-				, identifier as Identifier
-				, name as Name
-				, gender as Gender
-				, age as Age
-				, status as Status
-
-		FROM
-		(
-
-			SELECT DISTINCT
-					reg.location_name
-					, reg.id
-					, reg.name
-					, reg.gender
-					, reg.age
-					, reg.identifier
-					, IF(init.id is not null, 'Intake', 'No Intake') AS status
-			FROM
-					((SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,				
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id				
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE)and o.date_created <= CAST('#enddate#' AS DATE)) reg
-
-					LEFT JOIN 
-
-					(SELECT DISTINCT
-							p.person_id as id,
-							concat(pn.given_name,' ', ifnull(pn.family_name,'')) as name,
-							p.gender AS gender,
-							floor(datediff(CAST('#enddate#' AS DATE), p.birthdate)/365) AS age,				
-							pi.identifier as identifier,
-							concat("",p.uuid) as uuid,
-							concept_id,
-							l.name as location_name
-					FROM visit v
-							JOIN person_name pn on v.patient_id = pn.person_id and pn.voided=0
-							JOIN person p on p.person_id = v.patient_id
-							JOIN patient_identifier pi on v.patient_id = pi.patient_id 
-							JOIN patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
-							JOIN encounter en on en.visit_id = v.visit_id and en.voided=0
-							JOIN obs o on o.encounter_id=en.encounter_id and o.concept_id=4153
-							JOIN location l on v.location_id = l.location_id and l.retired=0
-					WHERE en.encounter_datetime <= CAST('#enddate#' AS DATE) and o.date_created <= CAST('#enddate#' AS DATE)) init
-					
-					ON reg.id = init.id)			
-					
-		) AS IntakesRegistered
-		WHERE IntakesRegistered.id in (select distinct os.person_id from obs os where os.concept_id=1158)
-		GROUP BY IntakesRegistered.id
+					) AS IntakesRegistered
 
 ) AS RegistrationVsIntakes
-ORDER BY  RegistrationVsIntakes.id, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
-
-
-
+ORDER BY  RegistrationVsIntakes.Identifier, RegistrationVsIntakes.location_name, RegistrationVsIntakes.status
 
 ) AS Intakes_vs_Registrations_Agg

--- a/openmrs/apps/reports/sql/egpaf/txcurr_combined_list.sql
+++ b/openmrs/apps/reports/sql/egpaf/txcurr_combined_list.sql
@@ -25,6 +25,13 @@
 							AND MONTH(os.obs_datetime) = MONTH(CAST('#endDate#' AS DATE)) 
 							AND YEAR(os.obs_datetime) = YEAR(CAST('#endDate#' AS DATE))
 						 )	
+
+						 and o.person_id not in (
+									select person_id 
+									from person 
+									where death_date <= cast('#endDate#' as date)
+									and dead = 1 and voided = 0
+						 )
 						 
 						 INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
 						 INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
@@ -219,15 +226,23 @@ FROM
 		and active_clients.person_id not in (
 							
 									-- TOUTS
-									select distinct(person_id)
-									from
-									(
-										select os.person_id, CAST(max(os.obs_datetime) AS DATE) as latest_transferout
-										from obs os
-										where os.concept_id=2398 and os.voided = 0
-										group by os.person_id
-										having latest_transferout <= CAST('#endDate#' AS DATE)
-									) as TOUTS
+									select tout_clients.person_id
+                                from
+                                (select B.person_id, B.obs_group_id, B.obs_datetime AS latest_consultation
+                                    from obs B
+                                    inner join
+                                    (select person_id, max(obs_datetime), SUBSTRING(max(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+                                    from obs where concept_id = 2403
+                                    and obs_datetime <= cast('#endDate#' as date)
+                                    and voided = 0
+                                    group by person_id) as A
+                                    on A.observation_id = B.obs_group_id
+                                    where concept_id = 2398
+                                    and A.observation_id = B.obs_group_id
+                                    and voided = 0
+                                    group by B.person_id
+                                ) as tout_clients
+                                where tout_clients.latest_consultation < cast('#endDate#' as date)
 										
 										)
 			

--- a/openmrs/apps/reports/sql/egpaf/txcurr_combined_pivot.sql
+++ b/openmrs/apps/reports/sql/egpaf/txcurr_combined_pivot.sql
@@ -54,6 +54,13 @@ FROM
 							AND MONTH(os.obs_datetime) = MONTH(CAST('#endDate#' AS DATE)) 
 							AND YEAR(os.obs_datetime) = YEAR(CAST('#endDate#' AS DATE))
 						 )	
+
+						 and o.person_id not in (
+									select person_id 
+									from person 
+									where death_date <= cast('#endDate#' as date)
+									and dead = 1 and voided = 0
+						 )
 						 
 						 INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
 						 INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
@@ -245,15 +252,23 @@ FROM
 		and active_clients.person_id not in (
 							
 									-- TOUTS
-									select distinct(person_id)
-									from
-									(
-										select os.person_id, CAST(max(os.obs_datetime) AS DATE) as latest_transferout
-										from obs os
-										where os.concept_id=2398 and os.voided = 0
-										group by os.person_id
-										having latest_transferout <= CAST('#endDate#' AS DATE)
-									) as TOUTS
+										select tout_clients.person_id
+                                from
+                                (select B.person_id, B.obs_group_id, B.obs_datetime AS latest_consultation
+                                    from obs B
+                                    inner join
+                                    (select person_id, max(obs_datetime), SUBSTRING(max(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+                                    from obs where concept_id = 2403
+                                    and obs_datetime <= cast('#endDate#' as date)
+                                    and voided = 0
+                                    group by person_id) as A
+                                    on A.observation_id = B.obs_group_id
+                                    where concept_id = 2398
+                                    and A.observation_id = B.obs_group_id
+                                    and voided = 0
+                                    group by B.person_id
+                                ) as tout_clients
+                                where tout_clients.latest_consultation < cast('#endDate#' as date)
 										
 										)
 			
@@ -447,6 +462,13 @@ FROM
 							AND MONTH(os.obs_datetime) = MONTH(CAST('#endDate#' AS DATE)) 
 							AND YEAR(os.obs_datetime) = YEAR(CAST('#endDate#' AS DATE))
 						 )	
+
+						 and o.person_id not in (
+									select person_id 
+									from person 
+									where death_date <= cast('#endDate#' as date)
+									and dead = 1 and voided = 0
+						 )
 						 
 						 INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
 						 INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
@@ -639,15 +661,23 @@ FROM
 		and active_clients.person_id not in (
 							
 									-- TOUTS
-									select distinct(person_id)
-									from
-									(
-										select os.person_id, CAST(max(os.obs_datetime) AS DATE) as latest_transferout
-										from obs os
-										where os.concept_id=2398 and os.voided = 0
-										group by os.person_id
-										having latest_transferout <= CAST('#endDate#' AS DATE)
-									) as TOUTS
+									select tout_clients.person_id
+                                from
+                                (select B.person_id, B.obs_group_id, B.obs_datetime AS latest_consultation
+                                    from obs B
+                                    inner join
+                                    (select person_id, max(obs_datetime), SUBSTRING(max(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+                                    from obs where concept_id = 2403
+                                    and obs_datetime <= cast('#endDate#' as date)
+                                    and voided = 0
+                                    group by person_id) as A
+                                    on A.observation_id = B.obs_group_id
+                                    where concept_id = 2398
+                                    and A.observation_id = B.obs_group_id
+                                    and voided = 0
+                                    group by B.person_id
+                                ) as tout_clients
+                                where tout_clients.latest_consultation < cast('#endDate#' as date)
 										
 										)
 			
@@ -784,4 +814,3 @@ ORDER BY Seen_Previous_ART_Clients.patientName)
  )
 ) AS Total_Aggregated_TxCurr
 ORDER BY Total_Aggregated_TxCurr.sort_order
-

--- a/openmrs/apps/reports/sql/txcurr_combined_list.sql
+++ b/openmrs/apps/reports/sql/txcurr_combined_list.sql
@@ -25,6 +25,13 @@
 							AND MONTH(os.obs_datetime) = MONTH(CAST('#endDate#' AS DATE)) 
 							AND YEAR(os.obs_datetime) = YEAR(CAST('#endDate#' AS DATE))
 						 )	
+
+						 and o.person_id not in (
+									select person_id 
+									from person 
+									where death_date <= cast('#endDate#' as date)
+									and dead = 1 and voided = 0
+						 )
 						 
 						 INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
 						 INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1

--- a/openmrs/apps/reports/sql/txcurr_combined_pivot.sql
+++ b/openmrs/apps/reports/sql/txcurr_combined_pivot.sql
@@ -54,6 +54,13 @@ FROM
 							AND MONTH(os.obs_datetime) = MONTH(CAST('#endDate#' AS DATE)) 
 							AND YEAR(os.obs_datetime) = YEAR(CAST('#endDate#' AS DATE))
 						 )	
+
+						 and o.person_id not in (
+									select person_id 
+									from person 
+									where death_date <= cast('#endDate#' as date)
+									and dead = 1 and voided = 0
+						 )
 						 
 						 INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
 						 INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
@@ -455,6 +462,13 @@ FROM
 							AND MONTH(os.obs_datetime) = MONTH(CAST('#endDate#' AS DATE)) 
 							AND YEAR(os.obs_datetime) = YEAR(CAST('#endDate#' AS DATE))
 						 )	
+
+						 and o.person_id not in (
+									select person_id 
+									from person 
+									where death_date <= cast('#endDate#' as date)
+									and dead = 1 and voided = 0
+						 )
 						 
 						 INNER JOIN person ON person.person_id = patient.patient_id AND person.voided = 0
 						 INNER JOIN person_name ON person.person_id = person_name.person_id AND person_name.preferred = 1
@@ -800,4 +814,3 @@ ORDER BY Seen_Previous_ART_Clients.patientName)
  )
 ) AS Total_Aggregated_TxCurr
 ORDER BY Total_Aggregated_TxCurr.sort_order
-


### PR DESCRIPTION
Modifications:
-TB-019 | TB Intakes (List) - Corrected to include intakes captured within a year of the report start date only
-TB-020 | TB Intakes (Pivot)- Aligned with the list version
-ART-001 | Current on ART Detailed (List) - Corrected to exclude dead patients from the initiated section of the report
-ART-002 | Current on ART Detailed (Pivot) - Aligned with the list version 
-ART-043 | TX_CURR (Pivot) - Corrected to exclude dead patients from the initiated section of the report
-ART-044 | TX_CURR (List) - Aligned with the list version

**json file modification: sql path of the intakes list has been changed**