### PR TITLE
Update cervical_scrn_list.sql

### DIFF
--- a/openmrs/apps/reports/sql/cervical_scrn_list.sql
+++ b/openmrs/apps/reports/sql/cervical_scrn_list.sql
@@ -54,7 +54,7 @@ left outer join
            else ""
        end AS VIA_Result
        from obs os 
-       where os.concept_id = 327
+       where os.concept_id = 327 and os.concept_id = 4511
        and os.voided = 0
        AND CAST(os.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
        AND CAST(os.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)


### PR DESCRIPTION
The was duplication in the list where if a client have received both PNC and cervical scrn services would appears twice in the cervical cancer screening list. This patch removes linkage to the PNC service. modification on line 53