### PR TITLE
show or hide anc visit number

### DIFF
--- a/openmrs/apps/clinical/formConditions.js
+++ b/openmrs/apps/clinical/formConditions.js
@@ -707,18 +707,21 @@ Bahmni.ConceptSet.FormConditions.rules = {
                         conditions.hide.push("ANC, Partner HIV Status");
                                 
                         if (AncVisits == "ANC, First Visit") {
+                                conditions.hide.push("ANC, Visit order Number");
                                 conditions.show.push("Lesotho Obstetric Record")
                                 conditions.show.push("ANC Register");
                                 conditions.hide.push("Subsequent HIV Test Results");
                         }
                         else if (AncVisits == "ANC, Subsequent Visit") {
+                                conditions.show.push("ANC, Visit order Number");
                                 conditions.show.push("ANC Register");
                                 conditions.hide.push("ANC, TT Doses Previous");
                                 conditions.hide.push("ANC From Lesotho");
                                 conditions.hide.push("Lesotho Obstetric Record");
                         }
                         else {
-                                conditions.hide.push("Lesotho Obstetric Record")
+                                conditions.hide.push("ANC, Visit order Number");
+                                conditions.hide.push("Lesotho Obstetric Record");
                                 conditions.hide.push("ANC Register");
                         }
                         

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "day" : "20",
-    "month" : "Nov",
-    "year" : "2023"
+    "day" : "25",
+    "month" : "Jan",
+    "year" : "2024"
 }


### PR DESCRIPTION
When 'First Visit' is selected in the ANC form, hide the visit order number field and only show it when 'Subsequent Visit' is selected