### PR TITLE
add genex results on patient dashboard

### DIFF
--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -94,9 +94,11 @@
                         "eRegister Lab Order Number",
                         "DISA, VL Result [#/vol]", 
                         "DISA, VL Result [log#/vol]",
-                        "DISA, VL Result (low value)", 
+                        "DISA, VL Result (low value)",
+                        "DISA, GeneXpert Result, MTB Result", 
+                        "DISA, GeneXpert Result, Rifampicin", 
                         "DISA, VL Result Testdate",
-                        "DISA, VL Result Comments"
+                        "DISA, Result Comments"
                         ],
                    "numberOfVisits": "4",
                    "showHeader": true,
@@ -107,9 +109,11 @@
                         "eRegister Lab Order Number",
                         "DISA, VL Result [#/vol]", 
                         "DISA, VL Result [log#/vol]",
-                        "DISA, VL Result (low value)", 
+                        "DISA, VL Result (low value)",
+                        "DISA, GeneXpert Result, MTB Result" ,
+                        "DISA, GeneXpert Result, Rifampicin", 
                         "DISA, VL Result Testdate",
-                        "DISA, VL Result Comments",
+                        "DISA, Result Comments",
                         "HIVTC, VL Pregnancy Status",
                         "HIVTC, VL Breastfeeding Status"
                         ],

--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -98,7 +98,7 @@
                         "DISA, GeneXpert Result, MTB Result", 
                         "DISA, GeneXpert Result, Rifampicin", 
                         "DISA, VL Result Testdate",
-                        "DISA, Result Comments"
+                        "DISA, VL Result Comments"
                         ],
                    "numberOfVisits": "4",
                    "showHeader": true,
@@ -113,7 +113,7 @@
                         "DISA, GeneXpert Result, MTB Result" ,
                         "DISA, GeneXpert Result, Rifampicin", 
                         "DISA, VL Result Testdate",
-                        "DISA, Result Comments",
+                        "DISA, VL Result Comments",
                         "HIVTC, VL Pregnancy Status",
                         "HIVTC, VL Breastfeeding Status"
                         ],


### PR DESCRIPTION
Renamed the comments concept to DISA, Result Comments so that it can be used for VL and TB results comments
Added the following TB GeneXpert results concepts to the labOrdersControl
- DISA, GeneXpert Result, MTB Result
- DISA, GeneXpert Result, Rifampicin