### PR TITLE
Matched result against correct lab order number for patients with multiple entries and added TAT

### DIFF
--- a/openmrs/apps/reports/sql/Test_Sent_VS_Received.sql
+++ b/openmrs/apps/reports/sql/Test_Sent_VS_Received.sql
@@ -1,16 +1,18 @@
-Select patientIdentifier as "Patient Identifier", ART_Number as "ART Number", patientName as "Patient Name",age_group, Age, Gender, 
-        date_collected as "Date Specimen Collected",Test, Lab_Order_Number as "Lab Order Number", Results,date_received as "Date Results Received", sort_order
+Select patientIdentifier as "Patient Identifier",  patientName as "Patient Name",age_group, Age, Gender, 
+        date_collected as "Date Specimen Collected",Test, Lab_Order_Number as "Lab Order Number", Results,result_date as "Date Results Received", 
+        datediff(result_date, date_collected) as "Turn Around Time(days)"
 From
 (select distinct patient.patient_id AS Id,
                 patient_identifier.identifier AS patientIdentifier,
-                p.identifier as ART_Number,
+                -- p.identifier as ART_Number,
                 concat(person_name.given_name, " ", person_name.family_name) AS patientName,
                 floor(datediff(CAST('#endDate#' AS DATE), person.birthdate)/365) AS Age,
                 person.gender AS Gender,
                 cast(o.date_created as date) as date_collected,
                 observed_age_group.name AS age_group,
                 "Done" AS Test,
-                observed_age_group.sort_order AS sort_order
+                observed_age_group.sort_order AS sort_order,
+		order_id
 
             from orders o
             -- Viral Load Tests Sent
@@ -22,73 +24,48 @@ From
                     CAST('#endDate#' AS DATE) BETWEEN (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.min_years YEAR), INTERVAL observed_age_group.min_days DAY))
                     AND (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
                     AND o.concept_id = 5484
-                    LEFT OUTER JOIN patient_identifier p ON p.patient_id = person.person_id AND p.identifier_type = 5
+                    -- LEFT OUTER JOIN patient_identifier p ON p.patient_id = person.person_id AND p.identifier_type = 5
                 WHERE observed_age_group.report_group_name = 'Modified_Ages'
                 AND CAST(o.date_created AS DATE) >= CAST('#startDate#' AS DATE)
                 AND CAST(o.date_created AS DATE) <= CAST('#endDate#' AS DATE)) as test
+
 Left Outer Join
-(
-    Select pId, Results
+
+(Select person_id, Lab_Order_Number, lab_order.order_id as orders_id , VL_result.order_id, VL_result.Results, result_date 
+FROM
+(select person_id, cast(obs_datetime as date)as max_observation, SUBSTRING(CONCAT(obs_datetime, obs_id), 20) AS observation_id, order_id, value_text  as Lab_Order_Number
+        from obs where concept_id = 5498 -- Lab order number
+		and cast(obs_datetime as date) >= cast('#startDate#' as date)
+        and cast(obs_datetime as date) <= cast('#endDate#' as date)
+        and voided = 0
+        -- group by person_id
+		)lab_order
+
+left outer join
+
+(Select pId, result.order_id, Results, cast(obs_datetime as date) as result_date
     From
       (
-        select oss.person_id as pId, concat(oss.value_numeric, " ", "copies/ml")  as Results
+        select oss.person_id as pId, concat(oss.value_numeric, " ", "copies/ml")  as Results, order_id, oss.obs_datetime
             from obs oss
             where oss.concept_id = 5485
             and oss.voided=0
-            and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
+            and cast(oss.obs_datetime as date) >= cast('#startDate#' as date)
             group by oss.person_id
 
     UNION
 
-    select oss.person_id as pId, "LDL"  as Results
+    select oss.person_id as pId, "LDL"  as Results, order_id, oss.obs_datetime
             from obs oss
             where oss.concept_id = 5489
             and oss.voided=0
-            and cast(oss.obs_datetime as date)  <= cast('#endDate#' as date)
+            and cast(oss.obs_datetime as date)  >= cast('#startDate#' as date)
             group by oss.person_id
 
-      ) As received_results
-    
+      )result
+      )VL_result
+	  on lab_order.order_id = VL_result.order_id
 
-) as received
-on test.Id = received.pId
-
-Left Outer Join
-(
-    Select pId, date_received
-    From
-      (
-        select oss.person_id as pId, cast(oss.obs_datetime as date) as date_received
-            from obs oss
-            where oss.concept_id = 5485
-            and oss.voided=0
-            and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-            group by oss.person_id
-
-    UNION
-
-    select oss.person_id as pId, cast(oss.obs_datetime as date) as date_received
-            from obs oss
-            where oss.concept_id = 5489
-            and oss.voided=0
-            and cast(oss.obs_datetime as date)  <= cast('#endDate#' as date)
-            group by oss.person_id
-
-      ) As received_date
-    
-
-) as date_rec
-on test.Id = date_rec.pId
-
-Left Outer Join
-(
-    
-        select oss.person_id as pId, oss.value_text  as Lab_Order_Number
-            from obs oss
-            where oss.concept_id = 5498
-            and oss.voided=0
-            and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-            group by oss.person_id
-    
-) as lab_order
-on test.Id = lab_order.pId
+)lab_orders	
+on test.order_id = lab_orders.orders_id
+order by 2


### PR DESCRIPTION
Modified Report:

- LAB-001 | Lab_Report (List) : Added the Turn Around Time column and corrected the results. Some were matched against the incorrect Lab order numbers and this has been corrected.


