### PR TITLE
Modified_TxCurr

### DIFF
--- a/openmrs/apps/reports/sql/egpaf/txcurr_combined_list.sql
+++ b/openmrs/apps/reports/sql/egpaf/txcurr_combined_list.sql
@@ -165,22 +165,20 @@ AND Clients_Seen.Id not in
 					)
 AND Clients_Seen.Id not in (
 					-- Visitors
-								select o.person_id
-								from obs o
-								inner join
-										(
-										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-										from obs oss
-										where oss.concept_id = 3753 
-										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-										group by oss.person_id
-										)latest
-									on latest.person_id = o.person_id
-									where concept_id = 5416
-									and o.value_coded =1 and o.voided=0
-									and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select distinct os.person_id from obs os
+							where os.concept_id = 5416
+							AND os.value_coded = 1 and os.voided = 0
+							AND CAST(os.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+							AND CAST(os.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 						)
+AND Clients_Seen.Id not in (
+		select distinct p.person_id as Id
+		from person p
+		where dead = 1
+		and death_date <= CAST('#endDate#' AS DATE)	
+		and voided = 0
+
+)
 
 ORDER BY Clients_Seen.patientName)
 
@@ -275,21 +273,14 @@ FROM
 
 		and active_clients.person_id not in(
 									-- Visitors
-								select o.person_id
-								from obs o
-								inner join
-										(
-										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-										from obs oss
-										where oss.concept_id = 3753 
-										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-										group by oss.person_id
-										)latest
-									on latest.person_id = o.person_id
-									where concept_id = 5416
-									and o.value_coded =1 and o.voided=0
-									and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select person_id 
+							FROM
+								(select person_id, max(obs_datetime), SUBSTRING(MAX(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+								from obs where concept_id = 5416 
+								and value_coded = 1 and voided = 0
+								and cast(obs_datetime as date) <= cast('#endDate#' as date)
+								and voided = 0
+								group by person_id)visitor
 							)				 
 						 )
 						 -- end
@@ -405,21 +396,14 @@ UNION
 						 )
 		and active_clients.person_id not in (
 									-- Visitors
-								select o.person_id
-								from obs o
-								inner join
-										(
-										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-										from obs oss
-										where oss.concept_id = 3753 
-										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-										group by oss.person_id
-										)latest
-									on latest.person_id = o.person_id
-									where concept_id = 5416
-									and o.value_coded =1 and o.voided=0
-									and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select person_id 
+							FROM
+								(select person_id, max(obs_datetime), SUBSTRING(MAX(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+								from obs where concept_id = 5416 
+								and value_coded = 1 and voided = 0
+								and cast(obs_datetime as date) <= cast('#endDate#' as date)
+								and voided = 0
+								group by person_id)visitor
 						 )
 						 )
 						 -- end

--- a/openmrs/apps/reports/sql/egpaf/txcurr_combined_pivot.sql
+++ b/openmrs/apps/reports/sql/egpaf/txcurr_combined_pivot.sql
@@ -195,22 +195,20 @@ AND Clients_Seen.Id not in
 
 AND Clients_Seen.Id not in (
 						-- Visitors
-							select o.person_id
-							from obs o
-							inner join
-									(
-									select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-									SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-									from obs oss
-									where oss.concept_id = 3753 
-									and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-									group by oss.person_id
-									)latest
-								on latest.person_id = o.person_id
-								where concept_id = 5416
-								and o.value_coded =1 and o.voided=0
-								and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select distinct os.person_id from obs os
+							where os.concept_id = 5416
+							AND os.value_coded = 1 and os.voided = 0
+							AND CAST(os.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+							AND CAST(os.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 					)
+AND Clients_Seen.Id not in (
+		select distinct p.person_id as Id
+		from person p
+		where dead = 1
+		and death_date <= CAST('#endDate#' AS DATE)	
+		and voided = 0
+
+)
 ORDER BY Clients_Seen.patientName)
 
 UNION
@@ -300,21 +298,14 @@ FROM
 						 )
 		and active_clients.person_id not in (
 									-- Visitors
-								select o.person_id
-								from obs o
-								inner join
-										(
-										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-										from obs oss
-										where oss.concept_id = 3753 
-										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-										group by oss.person_id
-										)latest
-									on latest.person_id = o.person_id
-									where concept_id = 5416
-									and o.value_coded =1 and o.voided=0
-									and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select person_id 
+							FROM
+								(select person_id, max(obs_datetime), SUBSTRING(MAX(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+								from obs where concept_id = 5416 
+								and value_coded = 1 and voided = 0
+								and cast(obs_datetime as date) <= cast('#endDate#' as date)
+								and voided = 0
+								group by person_id)visitor
 						 )
 						 )
 						 -- end
@@ -427,21 +418,14 @@ FROM
 						 )
 		and active_clients.person_id not in (
 									-- Visitors
-							select o.person_id
-							from obs o
-							inner join
-									(
-									select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-									SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-									from obs oss
-									where oss.concept_id = 3753 
-									and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-									group by oss.person_id
-									)latest
-								on latest.person_id = o.person_id
-								where concept_id = 5416
-								and o.value_coded =1 and o.voided=0
-								and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select person_id 
+							FROM
+								(select person_id, max(obs_datetime), SUBSTRING(MAX(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+								from obs where concept_id = 5416 
+								and value_coded = 1 and voided = 0
+								and cast(obs_datetime as date) <= cast('#endDate#' as date)
+								and voided = 0
+								group by person_id)visitor
 						 )
 						 )
 						 -- end
@@ -656,23 +640,21 @@ AND Clients_Seen.Id not in
 					)
 AND Clients_Seen.Id not in (
 						-- Visitors
-						select o.person_id
-						from obs o
-						inner join
-								(
-								select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-								SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-								from obs oss
-								where oss.concept_id = 3753 
-								and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-								group by oss.person_id
-								)latest
-						on latest.person_id = o.person_id
-						where concept_id = 5416
-						and o.value_coded =1 and o.voided=0
-						and  cast(o.obs_datetime as date) = cast(max_observation as date)
+						select distinct os.person_id from obs os
+							where os.concept_id = 5416
+							AND os.value_coded = 1 and os.voided = 0
+							AND CAST(os.obs_datetime AS DATE) >= CAST('#startDate#' AS DATE)
+							AND CAST(os.obs_datetime AS DATE) <= CAST('#endDate#' AS DATE)
 
 							)
+AND Clients_Seen.Id not in (
+		select distinct p.person_id as Id
+		from person p
+		where dead = 1
+		and death_date <= CAST('#endDate#' AS DATE)	
+		and voided = 0
+
+)
 ORDER BY Clients_Seen.patientName
 		)
 
@@ -763,21 +745,14 @@ FROM
 						 )
 		and active_clients.person_id not in (
 									-- Visitors
-								select o.person_id
-								from obs o
-								inner join
-										(
-										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-										from obs oss
-										where oss.concept_id = 3753 
-										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-										group by oss.person_id
-										)latest
-								on latest.person_id = o.person_id
-								where concept_id = 5416
-								and o.value_coded =1 and o.voided=0
-								and  cast(o.obs_datetime as date) = cast(max_observation as date)
+								select person_id 
+								FROM
+								(select person_id, max(obs_datetime), SUBSTRING(MAX(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+								from obs where concept_id = 5416 
+								and value_coded = 1 and voided = 0
+								and cast(obs_datetime as date) <= cast('#endDate#' as date)
+								and voided = 0
+								group by person_id)visitor
 						 )
 						 )
 						 -- end
@@ -891,21 +866,14 @@ FROM
 						 )
 		and active_clients.person_id not in (
 									-- Visitors
-							select o.person_id
-							from obs o
-							inner join
-									(
-									select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-									SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-									from obs oss
-									where oss.concept_id = 3753 
-									and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-									group by oss.person_id
-									)latest
-							on latest.person_id = o.person_id
-							where concept_id = 5416
-							and o.value_coded =1 and o.voided=0
-							and  cast(o.obs_datetime as date) = cast(max_observation as date)
+							select person_id 
+							FROM
+								(select person_id, max(obs_datetime), SUBSTRING(MAX(CONCAT(obs_datetime, obs_id)), 20) AS observation_id
+								from obs where concept_id = 5416 
+								and value_coded = 1 and voided = 0
+								and cast(obs_datetime as date) <= cast('#endDate#' as date)
+								and voided = 0
+								group by person_id)visitor
 						 )	 
 
 						 )

--- a/openmrs/apps/reports/sql/txcurr_combined_list.sql
+++ b/openmrs/apps/reports/sql/txcurr_combined_list.sql
@@ -172,7 +172,7 @@ AND Clients_Seen.Id not in (
 										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
 										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
 										from obs oss
-										where oss.concept_id = 3753 
+										where oss.concept_id = 3753
 										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
 										group by oss.person_id
 										)latest
@@ -181,6 +181,14 @@ AND Clients_Seen.Id not in (
 									and o.value_coded =1 and o.voided=0
 									and  cast(o.obs_datetime as date) = cast(max_observation as date)
 						)
+AND Clients_Seen.Id not in (
+		select distinct p.person_id as Id
+		from person p
+		where dead = 1
+		and death_date <= CAST('#endDate#' AS DATE)	
+		and voided = 0
+
+)
 
 ORDER BY Clients_Seen.patientName)
 
@@ -432,6 +440,3 @@ UNION
 						  AND (DATE_ADD(DATE_ADD(person.birthdate, INTERVAL observed_age_group.max_years YEAR), INTERVAL observed_age_group.max_days DAY))
                    WHERE observed_age_group.report_group_name = 'Modified_Ages') AS Seen_Previous_ART_Clients
 ORDER BY Seen_Previous_ART_Clients.patientName)
-
-
-

--- a/openmrs/apps/reports/sql/txcurr_combined_pivot.sql
+++ b/openmrs/apps/reports/sql/txcurr_combined_pivot.sql
@@ -195,22 +195,30 @@ AND Clients_Seen.Id not in
 
 AND Clients_Seen.Id not in (
 						-- Visitors
-							select o.person_id
-							from obs o
-							inner join
-									(
-									select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-									SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-									from obs oss
-									where oss.concept_id = 3753 
-									and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-									group by oss.person_id
-									)latest
-								on latest.person_id = o.person_id
-								where concept_id = 5416
-								and o.value_coded =1 and o.voided=0
-								and  cast(o.obs_datetime as date) = cast(max_observation as date)
+						select o.person_id
+								from obs o
+								inner join
+										(
+										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
+										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
+										from obs oss
+										where oss.concept_id = 3753 
+										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
+										group by oss.person_id
+										)latest
+									on latest.person_id = o.person_id
+									where concept_id = 5416
+									and o.value_coded =1 and o.voided=0
+									and  cast(o.obs_datetime as date) = cast(max_observation as date)
 					)
+AND Clients_Seen.Id not in (
+		select distinct p.person_id as Id
+		from person p
+		where dead = 1
+		and death_date <= CAST('#endDate#' AS DATE)	
+		and voided = 0
+
+)
 ORDER BY Clients_Seen.patientName)
 
 UNION
@@ -300,7 +308,7 @@ FROM
 						 )
 		and active_clients.person_id not in (
 									-- Visitors
-								select o.person_id
+							select o.person_id
 								from obs o
 								inner join
 										(
@@ -428,20 +436,20 @@ FROM
 		and active_clients.person_id not in (
 									-- Visitors
 							select o.person_id
-							from obs o
-							inner join
-									(
-									select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-									SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-									from obs oss
-									where oss.concept_id = 3753 
-									and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-									group by oss.person_id
-									)latest
-								on latest.person_id = o.person_id
-								where concept_id = 5416
-								and o.value_coded =1 and o.voided=0
-								and  cast(o.obs_datetime as date) = cast(max_observation as date)
+								from obs o
+								inner join
+										(
+										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
+										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
+										from obs oss
+										where oss.concept_id = 3753 
+										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
+										group by oss.person_id
+										)latest
+									on latest.person_id = o.person_id
+									where concept_id = 5416
+									and o.value_coded =1 and o.voided=0
+									and  cast(o.obs_datetime as date) = cast(max_observation as date)
 						 )
 						 )
 						 -- end
@@ -657,22 +665,30 @@ AND Clients_Seen.Id not in
 AND Clients_Seen.Id not in (
 						-- Visitors
 						select o.person_id
-						from obs o
-						inner join
-								(
-								select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-								SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-								from obs oss
-								where oss.concept_id = 3753 
-								and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-								group by oss.person_id
-								)latest
-						on latest.person_id = o.person_id
-						where concept_id = 5416
-						and o.value_coded =1 and o.voided=0
-						and  cast(o.obs_datetime as date) = cast(max_observation as date)
+								from obs o
+								inner join
+										(
+										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
+										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
+										from obs oss
+										where oss.concept_id = 3753 
+										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
+										group by oss.person_id
+										)latest
+									on latest.person_id = o.person_id
+									where concept_id = 5416
+									and o.value_coded =1 and o.voided=0
+									and  cast(o.obs_datetime as date) = cast(max_observation as date)
 
 							)
+AND Clients_Seen.Id not in (
+		select distinct p.person_id as Id
+		from person p
+		where dead = 1
+		and death_date <= CAST('#endDate#' AS DATE)	
+		and voided = 0
+
+)
 ORDER BY Clients_Seen.patientName
 		)
 
@@ -774,10 +790,10 @@ FROM
 										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
 										group by oss.person_id
 										)latest
-								on latest.person_id = o.person_id
-								where concept_id = 5416
-								and o.value_coded =1 and o.voided=0
-								and  cast(o.obs_datetime as date) = cast(max_observation as date)
+									on latest.person_id = o.person_id
+									where concept_id = 5416
+									and o.value_coded =1 and o.voided=0
+									and  cast(o.obs_datetime as date) = cast(max_observation as date)
 						 )
 						 )
 						 -- end
@@ -892,20 +908,20 @@ FROM
 		and active_clients.person_id not in (
 									-- Visitors
 							select o.person_id
-							from obs o
-							inner join
-									(
-									select oss.person_id, MAX(oss.obs_datetime) as max_observation,
-									SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
-									from obs oss
-									where oss.concept_id = 3753 
-									and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
-									group by oss.person_id
-									)latest
-							on latest.person_id = o.person_id
-							where concept_id = 5416
-							and o.value_coded =1 and o.voided=0
-							and  cast(o.obs_datetime as date) = cast(max_observation as date)
+								from obs o
+								inner join
+										(
+										select oss.person_id, MAX(oss.obs_datetime) as max_observation,
+										SUBSTRING(MAX(CONCAT(oss.obs_datetime, oss.value_coded)), 20) as examination_timing
+										from obs oss
+										where oss.concept_id = 3753 
+										and cast(oss.obs_datetime as date) <= cast('#endDate#' as date)
+										group by oss.person_id
+										)latest
+									on latest.person_id = o.person_id
+									where concept_id = 5416
+									and o.value_coded =1 and o.voided=0
+									and  cast(o.obs_datetime as date) = cast(max_observation as date)
 						 )	 
 
 						 )

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "day" : "13",
-    "month" : "Feb",
+    "day" : "02",
+    "month" : "Jul",
     "year" : "2024"
 }


### PR DESCRIPTION
ART-001 | Current on ART Detailed (List) : Modified to exclude deceased clients who came for refill during reporting period under Seen Clients Section.
ART-002 | Current on ART Detailed (Pivot) : Modified to exclude deceased clients who came for refill during reporting period under Seen Clients Section.
ART-043 | TX_CURR (Pivot) :Modified to exclude deceased clients who came for refill during reporting period under Seen Clients Section.
ART-044 | TX_CURR (List) :Modified to exclude deceased clients who came for refill during reporting period under Seen Clients Section.